### PR TITLE
use the chunk to iterate records in the error case

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -19,7 +19,7 @@ class Fluent::ElasticsearchErrorHandler
     stats = Hash.new(0)
     meta = {}
     header = {}
-    chunk.msgpack_each do |rawrecord, time|
+    chunk.msgpack_each do |time, rawrecord|
       bulk_message = ''
       next unless rawrecord.is_a? Hash
       begin

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -58,7 +58,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
       ]
      }))
     @handler.handle_error(response, 'atag', records)
-    assert_equal(1, @plugin.error_events.size)
+    assert_equal(1, @plugin.error_events.instance_variable_get(:@time_array).size)
   end
 
   def test_retry_error
@@ -132,7 +132,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
       @handler.handle_error(response, 'atag', records)
     rescue Fluent::ElasticsearchOutput::RetryStreamError=>e
       failed = true
-      assert_equal 2, e.retry_stream.size
+      assert_equal 2, e.retry_stream.instance_variable_get(:@time_array).size
     end
     assert_true failed
 

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -35,7 +35,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
       @index = 0
     end
     def msgpack_each
-      @records.each { |item| yield(item[:record],item[:time]) }
+      @records.each { |item| yield(item[:time],item[:record]) }
     end
   end
 

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -19,7 +19,23 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
     end
 
     def emit_error_event(tag, time, record, e)
-        @error_events.add(time, record)
+      @error_events.add(time, record)
+    end
+
+    def process_message(tag, meta, header, time, record, bulk_message)
+      if record.has_key?('raise') && record['raise']
+        raise Exception('process_message')
+      end
+    end
+  end
+
+  class MockChunk
+    def initialize(records)
+      @records = records
+      @index = 0
+    end
+    def msgpack_each
+      @records.each { |item| yield(item[:record],item[:time]) }
     end
   end
 
@@ -42,7 +58,8 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
   end
 
   def test_dlq_400_responses
-    records = [{time: 123, record: "record"}]
+    records = [{time: 123, record: {"message"=>"record"}}]
+    chunk = MockChunk.new(records)
     response = parse_response(%({
       "took" : 0,
       "errors" : true,
@@ -57,15 +74,18 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
         }
       ]
      }))
-    @handler.handle_error(response, 'atag', records)
+    @handler.handle_error(response, 'atag', chunk, records.length)
     assert_equal(1, @plugin.error_events.instance_variable_get(:@time_array).size)
   end
 
   def test_retry_error
     records = []
-    5.times do |i|
-      records << {time: 12345, record: "record #{i}"}
+    error_records = Hash.new(false)
+    error_records.merge!({0=>true, 4=>true, 9=>true})
+    10.times do |i|
+      records << {time: 12345, record: {"message"=>"record #{i}","_id"=>i,"raise"=>error_records[i]}}
     end
+    chunk = MockChunk.new(records)
 
     response = parse_response(%({
       "took" : 1,
@@ -75,31 +95,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
           "create" : {
             "_index" : "foo",
             "_type"  : "bar",
-            "_id" : "abc",
-            "status" : 500,
-            "error" : {
-              "type" : "some unrecognized type",
-              "reason":"unrecognized error"
-            }
-          }
-        },
-        {
-          "create" : {
-            "_index" : "foo",
-            "_type"  : "bar",
-            "_id" : "abc",
-            "status" : 500,
-            "error" : {
-              "type" : "some unrecognized type",
-              "reason":"unrecognized error"
-            }
-          }
-        },
-        {
-          "create" : {
-            "_index" : "foo",
-            "_type"  : "bar",
-            "_id" : "abc",
+            "_id" : "1",
             "status" : 201
           }
         },
@@ -107,7 +103,19 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
           "create" : {
             "_index" : "foo",
             "_type"  : "bar",
-            "_id" : "abc",
+            "_id" : "2",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "3",
             "status" : 409
           }
         },
@@ -115,8 +123,43 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
           "create" : {
             "_index" : "foo",
             "_type"  : "bar",
-            "_id" : "abc",
+            "_id" : "5",
+            "status" : 500,
+            "error" : {
+              "reason":"unrecognized error - no type field"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "6",
+            "status" : 429,
+            "error" : {
+              "type" : "es_rejected_execution_exception",
+              "reason":"unable to fulfill request at this time, try again later"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "7",
             "status" : 400,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "8",
+            "status" : 500,
             "error" : {
               "type" : "some unrecognized type",
               "reason":"unrecognized error"
@@ -129,10 +172,16 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
 
     begin
       failed = false
-      @handler.handle_error(response, 'atag', records)
+      @handler.handle_error(response, 'atag', chunk, response['items'].length)
     rescue Fluent::ElasticsearchOutput::RetryStreamError=>e
       failed = true
-      assert_equal 2, e.retry_stream.instance_variable_get(:@time_array).size
+      assert_equal 3, e.retry_stream.instance_variable_get(:@time_array).size
+      assert_equal 2, e.records[0]['_id']
+      assert_equal 6, e.records[1]['_id']
+      assert_equal 8, e.records[2]['_id']
+      assert_equal(2, @plugin.error_events.length)
+      assert_equal 5, @plugin.error_events[0]['_id']
+      assert_equal 7, @plugin.error_events[1]['_id']
     end
     assert_true failed
 


### PR DESCRIPTION
pass the chunk to the error handler.  It will process each record
in the chunk in the same way that the plugin handles it, even
calling process_message() on a deep copy of the record.
All of the error handling has been moved into the error condition
in send_bulk, so that there is no error code in the regular,
non-error code path.  The only thing left is bulk_message_count
which must be done by the plugin and passed to the error
handling code.
ElasticsearchErrorHandler @records and @bulk_message_count are
now unused so I got rid of them.
I made sure that the tests covered all of the odd corner cases.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
